### PR TITLE
Access to all of PGP and added correct typings

### DIFF
--- a/src/nest-pgpromise.service.ts
+++ b/src/nest-pgpromise.service.ts
@@ -36,8 +36,8 @@ export class NestPgpromiseService implements INestPgpromiseService {
 
       const pgp = pg(initOptions);
       this._pgMain = pgp;
-      return this._pgMain;
     }
+    return this._pgMain;
   }
 
   async getPg(): Promise<pg.IDatabase<{}>> {

--- a/src/nest-pgpromise.service.ts
+++ b/src/nest-pgpromise.service.ts
@@ -3,39 +3,48 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { NEST_PGPROMISE_OPTIONS } from './constants';
 import { NestPgpromiseOptions } from './interfaces';
 import * as pg from 'pg-promise';
+import { IClient } from 'pg-promise/typescript/pg-subset';
 
 interface INestPgpromiseService {
-  getPg(): Promise<any>;
+  getPg(): Promise<pg.IDatabase<{}>>;
+  getMain(): pg.IMain;
 }
 
 @Injectable()
 export class NestPgpromiseService implements INestPgpromiseService {
   private readonly logger: Logger;
-  private _pgConnection: any;
+  private _pgConnection: Promise<pg.IDatabase<{}>>;
+  private _pgMain: pg.IMain;
   constructor(
     @Inject(NEST_PGPROMISE_OPTIONS)
     private _NestPgpromiseOptions: NestPgpromiseOptions,
   ) {
     this.logger = new Logger('NestPgpromiseService');
-   
   }
-
-  async getPg(): Promise<any> {
-    if (!this._pgConnection) {
-      const self = this;
+  getMain(): pg.IMain {
+    if (!this._pgMain) {
       const initOptions = {
         ...this._NestPgpromiseOptions.initOptions,
         ...{
           error(error, e) {
             if (e.cn) {
-              self.logger.error('EVENT:', error.message || error);
+              this.logger.error('EVENT:', error.message || error);
             }
           },
         },
       };
 
       const pgp = pg(initOptions);
-      this._pgConnection = pgp(this._NestPgpromiseOptions.connection);
+      this._pgMain = pgp;
+      return this._pgMain;
+    }
+  }
+
+  async getPg(): Promise<pg.IDatabase<{}>> {
+    if (!this._pgConnection) {
+      this._pgConnection = this.getMain()(
+        this._NestPgpromiseOptions.connection,
+      );
     }
     return this._pgConnection;
   }


### PR DESCRIPTION
Added getMain() where you have access to pgp so you can use utilities, helpers, etc.
getMain() works the same way as getPg() does, using the initial configuration to create it only the first time
getPg() was changed to instead of instantiating pgp, it delegates the task to getMain() and then uses the instance.