### PR TITLE
Fix errors not being passed to NestJS logger, extend error handling, and add type definitions

### DIFF
--- a/src/nest-pgpromise.service.ts
+++ b/src/nest-pgpromise.service.ts
@@ -21,7 +21,7 @@ export class NestPgpromiseService implements INestPgpromiseService {
       const initOptions = {
         ...this._NestPgpromiseOptions.initOptions,
         ...{
-          error(error, e) {
+          error(error: Error, e: pg.IEventContext) {
             const logger = new Logger('NestPgpromiseService');
             /** Connection related error */
             if (e.cn) {


### PR DESCRIPTION
### Change 1 - Add type definitions

Type definitions have been added to the pg-promise error handler function parameters.

- The error object is a plain NodeJS error type.
- The e object is of type `IEventContext` as defined in the [pg-promise documentation (error events)](https://vitaly-t.github.io/pg-promise/global.html#event:error).

### Change 2 - Unable to pass errors to the NestJS logger

The error event handler is unable to access the NestJS logger. When it attempts to use the logger, the following error is thrown:
```
Unexpected error in 'error' event handler.
TypeError: Cannot read properties of undefined (reading 'error')
```

The pg-promise library can access the NestJS logger by initializing the class inside of the error handler; If this is not the optimal solution, please let me know.

### Change 3 - Extend error logging functionality

Only connection-related errors got passed to the NestJS logging system. If a user has extended the functionality of the NestJS logger to write to a file or save logs, query errors would not be passed to the logger.

The library now differentiates between connection, query, and transaction errors.

Refer to the [pg-promise error event documentation](https://vitaly-t.github.io/pg-promise/global.html#event:error) to improve these changes further.